### PR TITLE
Fixing the new return type of LBmanager.reserveLB()

### DIFF
--- a/include/e2sarCP.hpp
+++ b/include/e2sarCP.hpp
@@ -205,7 +205,7 @@ namespace e2sar
          *
          * @return - 0 on success or error code with message on failure
          */
-        result<int> reserveLB(const std::string &lb_name,
+        result<u_int32_t> reserveLB(const std::string &lb_name,
                               const double &durationSeconds,
                               const std::vector<std::string> &senders);
 

--- a/src/e2sarCP.cpp
+++ b/src/e2sarCP.cpp
@@ -135,7 +135,7 @@ namespace e2sar
     }
 
     // reserve via duration in seconds
-    result<int> LBManager::reserveLB(const std::string &lb_name,
+    result<u_int32_t> LBManager::reserveLB(const std::string &lb_name,
                                      const double &durationSeconds,
                                      const std::vector<std::string> &senders)
     {

--- a/src/pybind/py_e2sar.cpp
+++ b/src/pybind/py_e2sar.cpp
@@ -260,7 +260,7 @@ PYBIND11_MODULE(e2sar_py, m) {
     // It is specifically designed to interface with Python datetime.timedelta
     lb_manager.def(
         "reserve_lb_seconds",
-        static_cast<result<int> (LBManager::*)(
+        static_cast<result<u_int32_t> (LBManager::*)(
             const std::string &,
             const double &,
             const std::vector<std::string> &


### PR DESCRIPTION
I think there was some kind of merge issue from 'sender' to 'main' - I updated the return type of LBmanager.reserveLB() to u_int32_t (to return the ID of the FPGA). So this should hopefully reconcile this, at least it compiles @cissieAB 