### PR TITLE
LB header fix

### DIFF
--- a/src/e2sarDPSegmenter.cpp
+++ b/src/e2sarDPSegmenter.cpp
@@ -687,7 +687,9 @@ namespace e2sar
         while (curOffset < eventEnd)
         {
             // fill out LB and RE headers
-            auto hdr = static_cast<LBREHdr*>(malloc(sizeof(LBREHdr)));
+            void *hdrspace = malloc(sizeof(LBREHdr));
+            // placement-new to construct the headers
+            auto hdr = new (hdrspace) LBREHdr();
             // allocate iov (this returns two entries)
             auto iov = static_cast<struct iovec*>(malloc(2*sizeof(struct iovec)));
 

--- a/test/mem_tests.cpp
+++ b/test/mem_tests.cpp
@@ -49,7 +49,9 @@ void useMallocs()
 {
     for(size_t i = 0; i < numBuffers; i++)
     {
-        hdrs[i] = static_cast<LBREHdr*>(malloc(sizeof(LBREHdr)));
+        void *space = malloc(sizeof(LBREHdr));
+
+        hdrs[i] = new (space) LBREHdr();
         iovecs[i] = static_cast<struct iovec*>(calloc(2, sizeof(struct iovec)));
     }
 


### PR DESCRIPTION
Found out that when I ripped out Boost memory pool support in favor of malloc() I forgot that pool's mallocs call LBREHdr constructor and thus both headers were malformed. They worked for back-to-back testing but not with a real LB. This patch provides the fix (also updated the benchmark I used to compare the behavior of malloc/calloc vs pools, vs new).

