### PR TITLE
Bracketing the Boost version

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -86,7 +86,7 @@ grpc_dep = dependency('grpc++', version: '>=1.54.1')
 # and meson can ONLY find it via BOOST_ROOT env variable
 # (i.e. setting cmake_prefix_path doesn't work)
 boost_dep = dependency('boost', modules: ['system', 'url', 'program_options', 'chrono', 'thread'], method: 'cmake', 
-        version: ['>=1.83.0', '<=1.85.0'])
+        version: ['>=1.83.0', '<=1.86.0'])
 
 # we include 'src' because auto-generated headers for gRPC stubs go there 
 inc = include_directories('include', 'src')

--- a/meson.build
+++ b/meson.build
@@ -85,7 +85,8 @@ grpc_dep = dependency('grpc++', version: '>=1.54.1')
 # it also doesn't produce a .pc file - only cmake-based configuration is possible
 # and meson can ONLY find it via BOOST_ROOT env variable
 # (i.e. setting cmake_prefix_path doesn't work)
-boost_dep = dependency('boost', modules: ['system', 'url', 'program_options', 'chrono', 'thread'], method: 'cmake', version: '>=1.83.0')
+boost_dep = dependency('boost', modules: ['system', 'url', 'program_options', 'chrono', 'thread'], method: 'cmake', 
+        version: ['>=1.83.0', '<=1.85.0'])
 
 # we include 'src' because auto-generated headers for gRPC stubs go there 
 inc = include_directories('include', 'src')


### PR DESCRIPTION
By popular demand. Things break with Boost 1.87 so we bracket the Boost version in meson.build to avoid this. 